### PR TITLE
feat: skip vcs directory trees during search

### DIFF
--- a/internal/deepclean/dirstats.go
+++ b/internal/deepclean/dirstats.go
@@ -1,0 +1,50 @@
+package deepclean
+
+import (
+	"context"
+	"io/fs"
+)
+
+// DirStats contains metadata for disk usage of a parent directory.
+type DirStats struct {
+	Files uint64
+	Bytes uint64
+}
+
+// Add combines two DirStats together to total their results.
+func (a DirStats) Add(b DirStats) DirStats {
+	return DirStats{
+		Files: a.Files + b.Files,
+		Bytes: a.Bytes + b.Bytes,
+	}
+}
+
+// StatDir walks the directory at path collecting the aggregate DirStats.
+// The operation respects context cancellation and will abort early if the context is cancelled.
+func StatDir(ctx context.Context, fsys fs.FS, path string) (DirStats, error) {
+	var t DirStats
+	err := fs.WalkDir(fsys, path, func(fpath string, d fs.DirEntry, err error) error {
+		// failed to read directory entry, abort
+		if err != nil {
+			return err
+		}
+
+		// if context is done, abort early
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		// get file info to read size
+		fi, err := d.Info()
+		if err != nil {
+			return err
+		}
+
+		t.Files++
+		if !d.IsDir() {
+			t.Bytes += uint64(fi.Size())
+		}
+		return nil
+	})
+	return t, err
+}

--- a/internal/deepclean/dirstats_test.go
+++ b/internal/deepclean/dirstats_test.go
@@ -1,0 +1,111 @@
+package deepclean
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"testing/fstest"
+)
+
+func TestDirStats_Add(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b DirStats
+		want DirStats
+	}{
+		{
+			a:    DirStats{Files: 0, Bytes: 0},
+			b:    DirStats{Files: 0, Bytes: 0},
+			want: DirStats{Files: 0, Bytes: 0},
+		},
+		{
+			a:    DirStats{Files: 101, Bytes: 123456789},
+			b:    DirStats{Files: 123, Bytes: 777777777},
+			want: DirStats{Files: 224, Bytes: 901234566},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.a.Add(tt.b); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("got %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStatDir(t *testing.T) {
+	// Create a single test filesystem to use for all test cases
+	testFS := fstest.MapFS{
+		"empty":                   {},                            // empty directory
+		"single/file.txt":         {Data: []byte("hello world")}, // 11 bytes
+		"multi/file1.txt":         {Data: []byte("content1")},    // 8 bytes
+		"multi/file2.txt":         {Data: []byte("content22")},   // 9 bytes
+		"multi/subdir/nested.txt": {Data: []byte("nested")},      // 6 bytes
+		"mixed/file.txt":          {Data: []byte("data")},        // 4 bytes
+		"mixed/subdir1/deep1.txt": {Data: []byte("deep1")},       // 5 bytes
+		"mixed/subdir2/deep2.txt": {Data: []byte("deep22")},      // 6 bytes
+		"mixed/subdir2/deep3.txt": {Data: []byte("deep333")},     // 7 bytes
+	}
+
+	tests := []struct {
+		name    string
+		path    string
+		want    DirStats
+		wantErr bool
+	}{
+		{
+			path: "empty",
+			want: DirStats{Files: 1, Bytes: 0}, // directory itself counts as 1 file
+		},
+		{
+			path: "single",
+			want: DirStats{Files: 2, Bytes: 11}, // directory + file
+		},
+		{
+			path: "multi",
+			want: DirStats{Files: 5, Bytes: 23}, // dir + file1 + file2 + subdir + nested.txt = 5 files, 8+9+6 = 23 bytes
+		},
+		{
+			path: "mixed",
+			want: DirStats{Files: 7, Bytes: 22}, // dir + file + subdir1 + subdir2 + deep1 + deep2 + deep3 = 7 files, 4+5+6+7 = 22 bytes
+		},
+		{
+			path:    "nonexistent",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			got, err := StatDir(t.Context(), testFS, tt.path)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("StatDir() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("StatDir() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStatDir_ContextCancellation(t *testing.T) {
+	testFS := fstest.MapFS{
+		"test/file1.txt": {Data: []byte("content1")},
+		"test/file2.txt": {Data: []byte("content2")},
+	}
+
+	// Create a cancelled context
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	_, err := StatDir(ctx, testFS, "test")
+	if err == nil {
+		t.Error("StatDir() should return error when context is cancelled")
+	}
+
+	if err != context.Canceled {
+		t.Errorf("StatDir() error = %v, want %v", err, context.Canceled)
+	}
+}

--- a/internal/deepclean/results.go
+++ b/internal/deepclean/results.go
@@ -1,19 +1,5 @@
 package deepclean
 
-// DirStats contains metadata for disk usage of a parent directory.
-type DirStats struct {
-	Files uint64
-	Bytes uint64
-}
-
-// Add combines two DirStats together to total their results.
-func (a DirStats) Add(b DirStats) DirStats {
-	return DirStats{
-		Files: a.Files + b.Files,
-		Bytes: a.Bytes + b.Bytes,
-	}
-}
-
 // Result wraps DirStats with the Path that was used to stat the data.
 //
 // It is used whenever a task may stat multiple directories and return the

--- a/internal/deepclean/results_test.go
+++ b/internal/deepclean/results_test.go
@@ -5,32 +5,6 @@ import (
 	"testing"
 )
 
-func TestDirStats_Add(t *testing.T) {
-	tests := []struct {
-		name string
-		a, b DirStats
-		want DirStats
-	}{
-		{
-			a:    DirStats{Files: 0, Bytes: 0},
-			b:    DirStats{Files: 0, Bytes: 0},
-			want: DirStats{Files: 0, Bytes: 0},
-		},
-		{
-			a:    DirStats{Files: 101, Bytes: 123456789},
-			b:    DirStats{Files: 123, Bytes: 777777777},
-			want: DirStats{Files: 224, Bytes: 901234566},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.a.Add(tt.b); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("got %+v, want %+v", got, tt.want)
-			}
-		})
-	}
-}
-
 func TestAggregate(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/deepclean/scan.go
+++ b/internal/deepclean/scan.go
@@ -1,27 +1,26 @@
 package deepclean
 
 import (
+	"context"
 	"io/fs"
-	"path"
 	"runtime"
-	"slices"
 	"sync"
 )
 
 // ScanTask contains fields to access the results of an ongoing Scan.
 //
-// If the underlying filepath Walk encounters a fatal error, the results
+// If the underlying filesystem Walk encounters a fatal error, the results
 // channel will be closed and Err() will return a non-nil value. Always
-// drain (*ScanTask).C prior to checking Err().
+// drain ScanTask.C prior to checking Err().
 //
-// If the underlying filepath Walk encounters a non-fatal error, the
-// walked directory will be silently skipped (for now).
+// If the underlying filesystem Walk encounters a non-fatal error, the
+// walked directory will be silently skipped.
 type ScanTask struct {
 	C   <-chan Result
 	err error
 }
 
-// Err returns the error status of the underlying filepath Walk performed by the
+// Err returns the error status of the underlying filesystem Walk performed by the
 // scanner. This will only be set once the Walk has exited, indicated by the
 // Results channel being closed.
 func (s ScanTask) Err() error {
@@ -31,83 +30,49 @@ func (s ScanTask) Err() error {
 // Scan walks the filesystem searching for directories matching the targets strings,
 // and then initiates a DirStats on the directory, returning the Results as they
 // occur on ScanTask.C.
-func Scan(fsys fs.FS, path string, targets []string) *ScanTask {
+func Scan(ctx context.Context, fsys fs.FS, path string, targets []string) *ScanTask {
 	resultsChan := make(chan Result)
-	scanner := ScanTask{C: resultsChan}
+	task := ScanTask{C: resultsChan}
+	maxWorkers := min(8, runtime.GOMAXPROCS(0))
+	searcher := NewSearcher(fsys, defaultSearchOpts)
 
 	go func() {
 		defer close(resultsChan)
-
-		// spawn worker pool to perform stating of matched target directories
-		// cap at 8 workers (modern SSDs have 4-8 channels)
-		workerCount := min(8, runtime.GOMAXPROCS(0))
-		matchedDirs := make(chan string)
 		var wg sync.WaitGroup
-		for range workerCount {
+		sem := make(semaphore, maxWorkers)
+
+		// Launch StatDir goroutines directly from callback to avoid buffering overhead.
+		// The semaphore provides backpressure: if StatDir operations are slow,
+		// the filesystem search will naturally slow down, preventing memory pressure.
+		task.err = searcher.Walk(path, targets, func(matchedPath string) error {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+
+			sem.Acquire()
 			wg.Add(1)
 			go func() {
+				defer sem.Release()
 				defer wg.Done()
-				for fpath := range matchedDirs {
-					s, err := Stat(fsys, fpath)
-					if err != nil {
-						continue
-					}
-					resultsChan <- Result{Path: fpath, Stats: s}
+				s, err := StatDir(ctx, fsys, matchedPath)
+				if err != nil {
+					// TODO: optional StatDir err logging goes here
+					return
 				}
+				resultsChan <- Result{Path: matchedPath, Stats: s}
 			}()
-		}
-
-		// primary file system walk looking for target directories
-		scanner.err = fs.WalkDir(fsys, path, func(fpath string, d fs.DirEntry, err error) error {
-			if err != nil {
-				// error on initial directory should be fatal
-				if path == fpath {
-					return err
-				}
-				// error anywhere else should skip the file, not abort the scan
-				// TODO: log only if verbose
-				// fmt.Fprintf(os.Stderr, "ERROR: %s\n", err)
-				return nil
-			}
-
-			// Positives are directories matching any target string. For each
-			// match, send to the worker pool to gather stats, but skip further
-			// walking of the subdir in this primary scan thread.
-			if d.IsDir() && inTargets(targets, fpath) {
-				matchedDirs <- fpath
-				return fs.SkipDir
-			}
 			return nil
 		})
-		close(matchedDirs)
+
 		wg.Wait()
 	}()
 
-	return &scanner
+	return &task
 }
 
-func inTargets(targets []string, fpath string) bool {
-	return slices.Contains(targets, path.Base(fpath))
-}
+// A semaphore is a counting semaphore implemented via a buffered channel.
+// To create a semaphore of capacity n, use make(semaphore, n).
+type semaphore chan struct{}
 
-// Stat walks the directory at path collecting the aggregate DirStats.
-func Stat(fsys fs.FS, path string) (DirStats, error) {
-	var t DirStats
-	err := fs.WalkDir(fsys, path, func(fpath string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-
-		fi, err := d.Info()
-		if err != nil {
-			return err
-		}
-
-		t.Files++
-		if !d.IsDir() {
-			t.Bytes += uint64(fi.Size())
-		}
-		return nil
-	})
-	return t, err
-}
+func (s semaphore) Acquire() { s <- struct{}{} }
+func (s semaphore) Release() { <-s }

--- a/internal/deepclean/scan_test.go
+++ b/internal/deepclean/scan_test.go
@@ -53,7 +53,7 @@ func TestScan(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			testdataFS := os.DirFS("testdata")
 			var rs []Result
-			scanner := Scan(testdataFS, tt.path, tt.targets)
+			scanner := Scan(t.Context(), testdataFS, tt.path, tt.targets)
 			for r := range scanner.C {
 				rs = append(rs, r)
 			}

--- a/internal/deepclean/search.go
+++ b/internal/deepclean/search.go
@@ -1,0 +1,79 @@
+package deepclean
+
+import (
+	"io/fs"
+	"slices"
+)
+
+// A Searcher performs walks of the filesystem looking for candidate directories.
+type Searcher struct {
+	fsys fs.FS
+	opts SearchOpts
+}
+
+// SearchOpts configures the behavior of a Searcher.
+type SearchOpts struct {
+	ExcludeDirs []string // Paths to always ignore (exact name match)
+}
+
+var defaultSearchOpts = SearchOpts{
+	ExcludeDirs: []string{".git", ".hg", ".svn", ".jj"},
+}
+
+// NewSearcher creates a new Searcher with the given filesystem and options.
+func NewSearcher(fsys fs.FS, opts SearchOpts) *Searcher {
+	return &Searcher{
+		fsys: fsys,
+		opts: opts,
+	}
+}
+
+// Walk begins the Searcher walking the filesystem at the given root path,
+// efficiently looking for directories matching any of the targets.
+//
+// It invokes the provided callback fn for each matched directory path, which
+// may return an error to abort the walk early.
+//
+// If the root path cannot be read, this function will return that error. Other
+// errors encountered while walking the filesystem will be ignored.
+func (s *Searcher) Walk(root string, targets []string, fn SearchWalkFunc) error {
+	walker := func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			// error on initial directory should be fatal
+			if root == p {
+				return err
+			}
+			// error anywhere else should skip the file, not abort the scan
+			// TODO: log only if verbose
+			// fmt.Fprintf(os.Stderr, "ERROR: %s\n", err)
+			return nil
+		}
+
+		if d.IsDir() {
+			dirname := d.Name()
+
+			// skip unwanted directories, do not descend into them
+			if slices.Contains(s.opts.ExcludeDirs, dirname) {
+				return fs.SkipDir
+			}
+
+			// check if this directory matches any of the targets.
+			// If so, apply the callback and skip descending
+			// further into this directory.
+			if slices.Contains(targets, dirname) {
+				if err := fn(p); err != nil {
+					return err // callback can abort the walk
+				}
+				return fs.SkipDir
+			}
+		}
+		return nil
+	}
+
+	return fs.WalkDir(s.fsys, root, walker)
+}
+
+// SearchWalkFunc is the callback function type used by Searcher.Walk.
+// It is called for each directory that matches the search targets.
+// Returning an error will abort the filesystem walk.
+type SearchWalkFunc func(matchedPath string) error

--- a/internal/deepclean/search_test.go
+++ b/internal/deepclean/search_test.go
@@ -1,0 +1,104 @@
+package deepclean
+
+import (
+	"errors"
+	"slices"
+	"testing"
+	"testing/fstest"
+)
+
+func TestSearcher_Walk(t *testing.T) {
+	testFS := fstest.MapFS{
+		"file.txt":                   {Data: []byte("content")},
+		"node_modules/package.json":  {Data: []byte("{}")},
+		"node_modules/lib/index.js":  {Data: []byte("code")},
+		"src/main.go":                {Data: []byte("package main")},
+		"vendor/pkg/lib.go":          {Data: []byte("package pkg")},
+		"target/classes/Main.class":  {Data: []byte("bytecode")},
+		"nested/node_modules/dep.js": {Data: []byte("dependency")},
+		"nested/src/code.go":         {Data: []byte("code")},
+		".git/config":                {Data: []byte("git config")},
+		"docs/readme.md":             {Data: []byte("documentation")},
+	}
+
+	tests := []struct {
+		name    string
+		root    string
+		targets []string
+		want    []string
+		wantErr bool
+	}{
+		{
+			name:    "find single target",
+			root:    ".",
+			targets: []string{"node_modules"},
+			want:    []string{"node_modules", "nested/node_modules"},
+		},
+		{
+			name:    "find multiple targets",
+			root:    ".",
+			targets: []string{"node_modules", "vendor", "target"},
+			want:    []string{"node_modules", "vendor", "target", "nested/node_modules"},
+		},
+		{
+			name:    "no matches",
+			root:    ".",
+			targets: []string{"nonexistent"},
+			want:    []string{},
+		},
+		{
+			name:    "search subdirectory",
+			root:    "nested",
+			targets: []string{"node_modules"},
+			want:    []string{"nested/node_modules"},
+		},
+		{
+			name:    "error reading root path",
+			root:    "nonexistent",
+			targets: []string{"node_modules"},
+			want:    []string{},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			searcher := NewSearcher(testFS, defaultSearchOpts)
+			matches := make([]string, 0)
+			err := searcher.Walk(tt.root, tt.targets, func(matchedPath string) error {
+				matches = append(matches, matchedPath)
+				return nil
+			})
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Searcher.Walk() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			// Sort both slices for comparison since order may vary
+			got := slices.Sorted(slices.Values(matches))
+			want := slices.Sorted(slices.Values(tt.want))
+			if !slices.Equal(got, want) {
+				t.Errorf("Searcher.Walk() sorted matches = %v, want %v", got, want)
+			}
+		})
+	}
+}
+
+// Verify that if the callback returns an error, the walk is aborted and the error is propagated.
+func TestSearcher_Walk_CallbackError(t *testing.T) {
+	testFS := fstest.MapFS{
+		"node_modules/package.json": {Data: []byte("{}")}, // need at least one match to invoke the match callback
+		"vendor/lib.go":             {Data: []byte("code")},
+	}
+
+	var specificErr = errors.New("my specific error")
+	searcher := NewSearcher(testFS, defaultSearchOpts)
+	fn := func(matchedPath string) error {
+		return specificErr // Return error to abort walk
+	}
+	err := searcher.Walk(".", []string{"node_modules", "vendor"}, fn)
+
+	if err != specificErr {
+		t.Errorf("Searcher.Walk() error = %v, want %v", err, specificErr)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -36,7 +36,7 @@ func main() {
 	}
 
 	fsys := os.DirFS(dirname)
-	scanner := deepclean.Scan(fsys, ".", targets)
+	scanner := deepclean.Scan(context.Background(), fsys, ".", targets)
 	monitorResults(scanner)
 }
 


### PR DESCRIPTION
This PR optimizes filesystem search performance by skipping version control system directories (.git, .hg, .svn, .jj) that typically contain many files but should never produce matches. It restructures the codebase to be more modular by separating search functionality from scanning, while simplifying the concurrency model.

Key changes:
- Introduced a configurable Searcher component that can exclude VCS directories
- Replaced the worker pool pattern with a semaphore-based approach for cleaner concurrency control
- Added context support for cancellation throughout the scanning process